### PR TITLE
Remove `--mount` from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ WORKDIR /app
 
 # Build our application as a static build.
 # The mount options add the build cache to Docker to speed up multiple builds.
-RUN --mount=type=cache,target=/root/.cache/go-build \
-	--mount=type=cache,target=/go/pkg \
-	go build -ldflags '-s -w -extldflags "-static"' -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/myapp ./cmd/api
+#RUN #--mount=type=cache,target=/root/.cache/go-build \
+#	--mount=type=cache,target=/go/pkg \
+RUN go build -ldflags '-s -w -extldflags "-static"' -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/myapp ./cmd/api
 
 # Download the static build of Litestream directly into the path & make it executable.
 # This is done in the builder and copied as the chmod doubles the size.


### PR DESCRIPTION
This is a hotfix. Caprover is failing to build stating that BuildKit is not enabled. The server has Docker 20.10 and BuildKit has been enabled in `/etc/docker/daemon.json`.

I've disabled the `--mount` options to see if the container can build. 