### PR TITLE
Handle redirects server-side

### DIFF
--- a/cmd/api/links.go
+++ b/cmd/api/links.go
@@ -3,11 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/danielmichaels/shortlink-go/internal/data"
 	"github.com/danielmichaels/shortlink-go/internal/validator"
 	"github.com/gorilla/mux"
 	"github.com/tomasen/realip"
-	"net/http"
 )
 
 func (app *application) showLinkHandler() http.HandlerFunc {
@@ -38,14 +39,13 @@ func (app *application) showLinkHandler() http.HandlerFunc {
 			return
 		}
 
-		err = app.writeJSON(w, http.StatusOK, envelope{"link": link}, nil)
+		// Use a temporary redirect status in case we want to support changing
+		// redirect targets in the future.
+		http.Redirect(w, r, link.OriginalURL, http.StatusTemporaryRedirect)
 		app.logger.PrintInfo("link data", map[string]string{
 			"link.hash":         link.Hash,
 			"link.original_url": link.OriginalURL,
 		})
-		if err != nil {
-			app.serverErrorResponse(w, r, err)
-		}
 	}
 
 }


### PR DESCRIPTION
This moves the redirect logic from the frontend to the backend, allowing the server to redirect the browser with a simple HTTP 302.

This is faster and makes it easier to debug with standard HTTP tools, though there may be other reasons for doing the redirect client-side.