### PR TITLE
Remove required environment variables

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  build:
+  tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -18,27 +18,8 @@ jobs:
       with:
         go-version: 1.17
 
-#    - name: Build
-#      env:
-#        SERVER_PORT: ${{ secrets.SERVER_PORT }}
-#        SERVER_TIMEOUT_READ: 5s
-#        SERVER_TIMEOUT_WRITE: 10s
-#        SERVER_TIMEOUT_IDLE: 120s
-#        DB_NAME: ${{ secrets.DB_NAME }}
-#        DEBUG: 0
-#        LOCAL: 0
-#        ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
-#        API_DOMAIN: ${{ secrets.API_DOMAIN }}
-#        FRONTEND_DOMAIN: ${{ secrets.FRONTEND_DOMAIN }}
-#        RATE_LIMIT_ENABLED: true
-#        RATE_LIMIT_RPS: ${{ secrets.RATE_LIMIT_RPS }}
-#        RATE_LIMIT_BURST: ${{ secrets.RATE_LIMIT_BURST }}
-#        LITESTREAM_LOCAL_DB_PATH: ${{ secrets.LITESTREAM_LOCAL_DB_PATH }}
-#        DB_SYNC_INTERVAL: ${{ secrets.DB_SYNC_INTERVAL }}
-#        S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-#        S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
-#        S3_DB_URL: ${{ secrets.S3_DB_URL }}
-#      run: go build -v ./...
+    - name: Build
+      run: go build -v ./...
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,46 +18,27 @@ jobs:
       with:
         go-version: 1.17
 
-    - name: Build
-      env:
-        SERVER_PORT: ${{ secrets.SERVER_PORT }}
-        SERVER_TIMEOUT_READ: 5s
-        SERVER_TIMEOUT_WRITE: 10s
-        SERVER_TIMEOUT_IDLE: 120s
-        DB_NAME: ${{ secrets.DB_NAME }}
-        DEBUG: 0
-        LOCAL: 0
-        ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
-        API_DOMAIN: ${{ secrets.API_DOMAIN }}
-        FRONTEND_DOMAIN: ${{ secrets.FRONTEND_DOMAIN }}
-        RATE_LIMIT_ENABLED: true
-        RATE_LIMIT_RPS: ${{ secrets.RATE_LIMIT_RPS }}
-        RATE_LIMIT_BURST: ${{ secrets.RATE_LIMIT_BURST }}
-        LITESTREAM_LOCAL_DB_PATH: ${{ secrets.LITESTREAM_LOCAL_DB_PATH }}
-        DB_SYNC_INTERVAL: ${{ secrets.DB_SYNC_INTERVAL }}
-        S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-        S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
-        S3_DB_URL: ${{ secrets.S3_DB_URL }}
-      run: go build -v ./...
+#    - name: Build
+#      env:
+#        SERVER_PORT: ${{ secrets.SERVER_PORT }}
+#        SERVER_TIMEOUT_READ: 5s
+#        SERVER_TIMEOUT_WRITE: 10s
+#        SERVER_TIMEOUT_IDLE: 120s
+#        DB_NAME: ${{ secrets.DB_NAME }}
+#        DEBUG: 0
+#        LOCAL: 0
+#        ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
+#        API_DOMAIN: ${{ secrets.API_DOMAIN }}
+#        FRONTEND_DOMAIN: ${{ secrets.FRONTEND_DOMAIN }}
+#        RATE_LIMIT_ENABLED: true
+#        RATE_LIMIT_RPS: ${{ secrets.RATE_LIMIT_RPS }}
+#        RATE_LIMIT_BURST: ${{ secrets.RATE_LIMIT_BURST }}
+#        LITESTREAM_LOCAL_DB_PATH: ${{ secrets.LITESTREAM_LOCAL_DB_PATH }}
+#        DB_SYNC_INTERVAL: ${{ secrets.DB_SYNC_INTERVAL }}
+#        S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+#        S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+#        S3_DB_URL: ${{ secrets.S3_DB_URL }}
+#      run: go build -v ./...
 
     - name: Test
-      env:
-        SERVER_PORT: ${{ secrets.SERVER_PORT }}
-        SERVER_TIMEOUT_READ: 5s
-        SERVER_TIMEOUT_WRITE: 10s
-        SERVER_TIMEOUT_IDLE: 120s
-        DB_NAME: ${{ secrets.DB_NAME }}
-        DEBUG: 0
-        LOCAL: 0
-        ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
-        API_DOMAIN: ${{ secrets.API_DOMAIN }}
-        FRONTEND_DOMAIN: ${{ secrets.FRONTEND_DOMAIN }}
-        RATE_LIMIT_ENABLED: true
-        RATE_LIMIT_RPS: ${{ secrets.RATE_LIMIT_RPS }}
-        RATE_LIMIT_BURST: ${{ secrets.RATE_LIMIT_BURST }}
-        LITESTREAM_LOCAL_DB_PATH: ${{ secrets.LITESTREAM_LOCAL_DB_PATH }}
-        DB_SYNC_INTERVAL: ${{ secrets.DB_SYNC_INTERVAL }}
-        S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-        S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
-        S3_DB_URL: ${{ secrets.S3_DB_URL }}
       run: go test -v ./...

--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -7,31 +7,30 @@ import (
 )
 
 type limiter struct {
-	Enabled bool    `env:"RATE_LIMIT_ENABLED,required"`
-	Rps     float64 `env:"RATE_LIMIT_RPS,required"`
-	Burst   int     `env:"RATE_LIMIT_BURST,required"`
+	Enabled bool    `env:"RATE_LIMIT_ENABLED,default=true"`
+	Rps     float64 `env:"RATE_LIMIT_RPS,default=2"`
+	Burst   int     `env:"RATE_LIMIT_BURST,default=4"`
 }
 
 type Conf struct {
-	Debug   bool `env:"DEBUG,required"`
+	Debug   bool `env:"DEBUG,default=false"`
 	Server  serverConf
 	Db      dbConf
 	Limiter limiter
-	Local   bool `env:"LOCAL,required"`
 }
 
 type dbConf struct {
-	DbName string `env:"DB_NAME,required"`
+	DbName string `env:"DB_NAME,default=./data/shorty.db"`
 }
 
 type serverConf struct {
-	Port           int           `env:"SERVER_PORT,required"`
-	TimeoutRead    time.Duration `env:"SERVER_TIMEOUT_READ,required"`
-	TimeoutWrite   time.Duration `env:"SERVER_TIMEOUT_WRITE,required"`
-	TimeoutIdle    time.Duration `env:"SERVER_TIMEOUT_IDLE,required"`
-	ApiDomain      string        `env:"API_DOMAIN,required"`      // server's domain
-	FrontendDomain string        `env:"FRONTEND_DOMAIN,required"` // server's domain
-	AllowedOrigins []string      `env:"ALLOWED_ORIGINS,required"` // server's domain
+	Port           int           `env:"SERVER_PORT,default=1987"`
+	TimeoutRead    time.Duration `env:"SERVER_TIMEOUT_READ,default=5s"`
+	TimeoutWrite   time.Duration `env:"SERVER_TIMEOUT_WRITE,default=10s"`
+	TimeoutIdle    time.Duration `env:"SERVER_TIMEOUT_IDLE,default=120s"`
+	ApiDomain      string        `env:"API_DOMAIN,default=http://localhost:1987"`      // server's domain
+	FrontendDomain string        `env:"FRONTEND_DOMAIN,default=http://localhost:1988"` // server's domain
+	AllowedOrigins []string      `env:"ALLOWED_ORIGINS,default=http://localhost:1988"` // server's domain
 }
 
 // AppConfig Setup and install the applications' configuration environment variables


### PR DESCRIPTION
Initially, I had set all environment variables as required. Instead, I've updated them with a `default` that can be overridden. 

This makes testing via GH actions much easier and alleviates any potential secret spillage from the way GH actions handle PR's. The really sensitive data is not required for running tests and has been omitted.